### PR TITLE
Feature/domain

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.postgresql:postgresql'
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/dawwson/todoappbe/domain/Advice.java
+++ b/src/main/java/dawwson/todoappbe/domain/Advice.java
@@ -1,0 +1,22 @@
+package dawwson.todoappbe.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+public class Advice {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "ADVICE_ID")
+    private UUID id;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private String author;
+
+}

--- a/src/main/java/dawwson/todoappbe/domain/BaseEntity.java
+++ b/src/main/java/dawwson/todoappbe/domain/BaseEntity.java
@@ -1,0 +1,15 @@
+package dawwson.todoappbe.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+public class BaseEntity {
+    @Column(updatable = false, nullable = false)  // 최초 insert 값 유지
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/dawwson/todoappbe/domain/Todo.java
+++ b/src/main/java/dawwson/todoappbe/domain/Todo.java
@@ -1,0 +1,27 @@
+package dawwson.todoappbe.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+public class Todo extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "TODO_ID")
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)  // 지연로딩
+    @JoinColumn(name = "USER_ID", nullable = false)  // 연관관계 주인
+    private User user;
+
+    @Column(nullable = false)
+    @ColumnDefault("false")
+    private Boolean isDone;
+
+    @Column(nullable = false)
+    private String content;
+}

--- a/src/main/java/dawwson/todoappbe/domain/User.java
+++ b/src/main/java/dawwson/todoappbe/domain/User.java
@@ -1,0 +1,26 @@
+package dawwson.todoappbe.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@Table(name = "users")
+public class User extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "USER_ID")
+    private UUID id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    // TODO: 필요해질 때 양방향 매핑 추가
+    //@OneToMany(mappedBy = "user")
+    //private List<Todo> todos = new ArrayList<>();
+}


### PR DESCRIPTION
## 이슈 번호 또는 링크
https://github.com/users/dawwson/projects/1?pane=issue&itemId=37009140
<br>

## 💡 변경 이유
- 새로운 기능 추가
<br>

## 🔑 주요 변경사항
- 도메인 작성
  - User, Todo, Advice
  - BaseEntity -> 생성일자, 수정일자만 있음
    - User, Todo 엔티티가 상속받는다.
- Hibernate ddl-auto: create로 설정하여 테이블 자동 생성
- MySQL에서 PostgreSQL로 변경
<br>

## 📷 테스트 결과
### [ 테이블 설계 ]
- ❄️ 표시 : unique
- 🔑 표시 : primary key
- 🔗 표시 : foreign key
- User와 Todo는 1:N 관계
<img width="1099" alt="image" src="https://github.com/dawwson/todo-app-be/assets/45624238/f77dfcae-1632-400c-b74d-a64889526194">

### [ 엔티티 설계 ]
<img width="686" alt="image" src="https://github.com/dawwson/todo-app-be/assets/45624238/e91e76ed-d73f-4b5d-9c3c-0b0e97e48577">


### [ 데이터 그립에서 diagram 추출한 결과 ]
<img width="465" alt="image" src="https://github.com/dawwson/todo-app-be/assets/45624238/d65729c5-68ae-4daa-ac8d-55d8f3590b34">

