### PR TITLE
Todo API 작성(조회, 생성)

### DIFF
--- a/src/main/java/dawwson/todoappbe/TodoAppBeApplication.java
+++ b/src/main/java/dawwson/todoappbe/TodoAppBeApplication.java
@@ -2,7 +2,9 @@ package dawwson.todoappbe;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class TodoAppBeApplication {
 

--- a/src/main/java/dawwson/todoappbe/controller/TodoApiController.java
+++ b/src/main/java/dawwson/todoappbe/controller/TodoApiController.java
@@ -1,14 +1,18 @@
 package dawwson.todoappbe.controller;
 
 import dawwson.todoappbe.controller.dto.GetTodosData;
+import dawwson.todoappbe.controller.dto.PostTodoData;
+import dawwson.todoappbe.controller.dto.PostTodoRequest;
 import dawwson.todoappbe.controller.dto.Response;
 import dawwson.todoappbe.domain.Todo;
 import dawwson.todoappbe.service.TodoService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,6 +32,20 @@ public class TodoApiController {
                 .code(200)
                 .message("Todo list is loaded successfully")
                 .data(collect)
+                .build();
+    }
+
+    @PostMapping("/api/v1/todos")
+    @ResponseStatus(HttpStatus.CREATED)
+    public Response<PostTodoData> postTodos(
+            @RequestBody @Valid PostTodoRequest request
+    ) {
+        UUID newTodoId = todoService.createTodo(request.getContent());
+
+        return Response.<PostTodoData>builder()
+                .code(201)
+                .message("Todo is created successfully")
+                .data(PostTodoData.of(newTodoId))
                 .build();
     }
 }

--- a/src/main/java/dawwson/todoappbe/controller/TodoApiController.java
+++ b/src/main/java/dawwson/todoappbe/controller/TodoApiController.java
@@ -1,0 +1,33 @@
+package dawwson.todoappbe.controller;
+
+import dawwson.todoappbe.controller.dto.GetTodosData;
+import dawwson.todoappbe.controller.dto.Response;
+import dawwson.todoappbe.domain.Todo;
+import dawwson.todoappbe.service.TodoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class TodoApiController {
+
+    private final TodoService todoService;
+
+    @GetMapping("/api/v1/todos")
+    public Response<List<GetTodosData>> getTodos() {
+        List<Todo> todos = todoService.findTodos();
+        List<GetTodosData> collect = todos
+                .stream()
+                .map(GetTodosData::of)
+                .toList();
+
+        return Response.<List<GetTodosData>>builder()
+                .code(200)
+                .message("Todo list is loaded successfully")
+                .data(collect)
+                .build();
+    }
+}

--- a/src/main/java/dawwson/todoappbe/controller/dto/GetTodosData.java
+++ b/src/main/java/dawwson/todoappbe/controller/dto/GetTodosData.java
@@ -1,0 +1,25 @@
+package dawwson.todoappbe.controller.dto;
+
+import dawwson.todoappbe.domain.Todo;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+public class GetTodosData {
+    private UUID id;
+    private boolean isDone;
+    private String content;
+    private LocalDateTime createdAt;
+
+    public static GetTodosData of(Todo todo) {
+        GetTodosData getTodosData = new GetTodosData();
+        getTodosData.id = todo.getId();
+        getTodosData.isDone = todo.getIsDone();
+        getTodosData.content = todo.getContent();
+        getTodosData.createdAt = todo.getCreatedAt();
+
+        return getTodosData;
+    }
+}

--- a/src/main/java/dawwson/todoappbe/controller/dto/PostTodoData.java
+++ b/src/main/java/dawwson/todoappbe/controller/dto/PostTodoData.java
@@ -1,0 +1,16 @@
+package dawwson.todoappbe.controller.dto;
+
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class PostTodoData {
+    private UUID id;
+
+    public static PostTodoData of(UUID id) {
+        PostTodoData postTodoData = new PostTodoData();
+        postTodoData.id = id;
+        return postTodoData;
+    }
+}

--- a/src/main/java/dawwson/todoappbe/controller/dto/PostTodoRequest.java
+++ b/src/main/java/dawwson/todoappbe/controller/dto/PostTodoRequest.java
@@ -1,0 +1,11 @@
+package dawwson.todoappbe.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class PostTodoRequest {
+    // TODO: String이 아닌 값이어도 String으로 형변환 되는 이유는??
+    @NotBlank
+    private String content;
+}

--- a/src/main/java/dawwson/todoappbe/controller/dto/Response.java
+++ b/src/main/java/dawwson/todoappbe/controller/dto/Response.java
@@ -1,0 +1,14 @@
+package dawwson.todoappbe.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+@Builder
+public class Response<T> {
+    private int code;
+    private String message;
+    private T data;
+}

--- a/src/main/java/dawwson/todoappbe/domain/BaseEntity.java
+++ b/src/main/java/dawwson/todoappbe/domain/BaseEntity.java
@@ -1,15 +1,24 @@
 package dawwson.todoappbe.domain;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+@Getter
 @MappedSuperclass
-public class BaseEntity {
-    @Column(updatable = false, nullable = false)  // 최초 insert 값 유지
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
     private LocalDateTime createdAt;
 
+    @LastModifiedDate
     @Column(nullable = false)
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/dawwson/todoappbe/domain/Todo.java
+++ b/src/main/java/dawwson/todoappbe/domain/Todo.java
@@ -1,5 +1,6 @@
 package dawwson.todoappbe.domain;
 
+import dawwson.todoappbe.service.dto.UpdateTodoDto;
 import jakarta.persistence.*;
 import lombok.Getter;
 import org.hibernate.annotations.ColumnDefault;
@@ -14,9 +15,10 @@ public class Todo extends BaseEntity {
     @Column(name = "TODO_ID")
     private UUID id;
 
-    @ManyToOne(fetch = FetchType.LAZY)  // 지연로딩
-    @JoinColumn(name = "USER_ID", nullable = false)  // 연관관계 주인
-    private User user;
+    // 임시 주석 처리 -> user 도메인 로직 만들고 해제
+    //@ManyToOne(fetch = FetchType.LAZY)  // 지연로딩
+    //@JoinColumn(name = "USER_ID", nullable = false)  // 연관관계 주인
+    //private User user;
 
     @Column(nullable = false)
     @ColumnDefault("false")
@@ -24,4 +26,24 @@ public class Todo extends BaseEntity {
 
     @Column(nullable = false)
     private String content;
+
+    /* 생성 메서드 */
+    public static Todo create(String content) {
+        Todo todo = new Todo();
+        //todo.user = user;
+        todo.isDone = false;
+        todo.content = content;
+
+        return todo;
+    }
+
+    /* 수정 메서드 */
+    public void update(UpdateTodoDto updateTodoDto) {
+        if (updateTodoDto.getIsDone() != null) {
+            this.isDone = updateTodoDto.getIsDone();
+        }
+        if (updateTodoDto.getContent() != null) {
+            this.content = updateTodoDto.getContent();
+        }
+    }
 }

--- a/src/main/java/dawwson/todoappbe/repository/TodoRepository.java
+++ b/src/main/java/dawwson/todoappbe/repository/TodoRepository.java
@@ -1,0 +1,37 @@
+package dawwson.todoappbe.repository;
+
+import dawwson.todoappbe.domain.Todo;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class TodoRepository {
+
+    private final EntityManager em;
+
+    public Todo findById(UUID id) {
+        return em.find(Todo.class, id);
+    }
+
+    // TODO: userId로 조회
+    public List<Todo> findAll() {
+        String jpql = "select t from Todo t";
+
+        return em
+                .createQuery(jpql, Todo.class)
+                .getResultList();
+    }
+
+    public void save(Todo todo) {
+        em.persist(todo);
+    }
+
+    public void delete(Todo todo) {
+        em.remove(todo);
+    }
+}

--- a/src/main/java/dawwson/todoappbe/service/TodoService.java
+++ b/src/main/java/dawwson/todoappbe/service/TodoService.java
@@ -1,0 +1,57 @@
+package dawwson.todoappbe.service;
+
+import dawwson.todoappbe.domain.Todo;
+import dawwson.todoappbe.repository.TodoRepository;
+import dawwson.todoappbe.service.dto.UpdateTodoDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TodoService {
+    private final TodoRepository todoRepository;
+
+    /**
+     * Todo 생성
+     * @param content - Todo 내용
+     * @return 생성된 todo의 id
+     */
+    public UUID createTodo(String content) {
+        Todo todo = Todo.create(content);
+        todoRepository.save(todo);
+
+        return todo.getId();  // 영속성 컨텍스트가 persist() 호출시 PK 획득
+    }
+
+    /**
+     * Todo 조회
+     * @return Todo 리스트
+     */
+    public List<Todo> findTodos() {
+        return todoRepository.findAll();
+    }
+
+    /**
+     * Todo 수정
+     * @param id - 수정할 Todo id
+     * @param updateTodoDto - 수정할 요소들
+     */
+    public void updateTodo(UUID id, UpdateTodoDto updateTodoDto) {
+        Todo todo = todoRepository.findById(id);
+        todo.update(updateTodoDto);
+    }
+
+    /**
+     * Todo 삭제
+     * @param id - 삭제할 Todo id
+     */
+    public void deleteTodo(UUID id) {
+        Todo todo = todoRepository.findById(id);
+        todoRepository.delete(todo);
+    }
+}

--- a/src/main/java/dawwson/todoappbe/service/TodoService.java
+++ b/src/main/java/dawwson/todoappbe/service/TodoService.java
@@ -18,7 +18,7 @@ public class TodoService {
 
     /**
      * Todo 생성
-     * @param content - Todo 내용
+     * @param content Todo 내용
      * @return 생성된 todo의 id
      */
     public UUID createTodo(String content) {
@@ -38,8 +38,8 @@ public class TodoService {
 
     /**
      * Todo 수정
-     * @param id - 수정할 Todo id
-     * @param updateTodoDto - 수정할 요소들
+     * @param id 수정할 Todo id
+     * @param updateTodoDto 수정할 요소들
      */
     public void updateTodo(UUID id, UpdateTodoDto updateTodoDto) {
         Todo todo = todoRepository.findById(id);
@@ -48,7 +48,7 @@ public class TodoService {
 
     /**
      * Todo 삭제
-     * @param id - 삭제할 Todo id
+     * @param id 삭제할 Todo id
      */
     public void deleteTodo(UUID id) {
         Todo todo = todoRepository.findById(id);

--- a/src/main/java/dawwson/todoappbe/service/TodoService.java
+++ b/src/main/java/dawwson/todoappbe/service/TodoService.java
@@ -21,6 +21,7 @@ public class TodoService {
      * @param content Todo 내용
      * @return 생성된 todo의 id
      */
+    @Transactional
     public UUID createTodo(String content) {
         Todo todo = Todo.create(content);
         todoRepository.save(todo);

--- a/src/main/java/dawwson/todoappbe/service/dto/UpdateTodoDto.java
+++ b/src/main/java/dawwson/todoappbe/service/dto/UpdateTodoDto.java
@@ -6,4 +6,17 @@ import lombok.Getter;
 public class UpdateTodoDto {
     private Boolean isDone;
     private String content;
+
+    public UpdateTodoDto(Boolean isDone) {
+        this.isDone = isDone;
+    }
+
+    public UpdateTodoDto(String content) {
+        this.content = content;
+    }
+
+    public UpdateTodoDto(Boolean isDone, String content) {
+        this.isDone = isDone;
+        this.content = content;
+    }
 }

--- a/src/main/java/dawwson/todoappbe/service/dto/UpdateTodoDto.java
+++ b/src/main/java/dawwson/todoappbe/service/dto/UpdateTodoDto.java
@@ -1,0 +1,9 @@
+package dawwson.todoappbe.service.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateTodoDto {
+    private Boolean isDone;
+    private String content;
+}

--- a/src/test/java/dawwson/todoappbe/service/TodoServiceTest.java
+++ b/src/test/java/dawwson/todoappbe/service/TodoServiceTest.java
@@ -4,7 +4,6 @@ import dawwson.todoappbe.domain.Todo;
 import dawwson.todoappbe.repository.TodoRepository;
 import dawwson.todoappbe.service.dto.UpdateTodoDto;
 import jakarta.persistence.EntityManager;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/src/test/java/dawwson/todoappbe/service/TodoServiceTest.java
+++ b/src/test/java/dawwson/todoappbe/service/TodoServiceTest.java
@@ -1,0 +1,91 @@
+package dawwson.todoappbe.service;
+
+import dawwson.todoappbe.domain.Todo;
+import dawwson.todoappbe.repository.TodoRepository;
+import dawwson.todoappbe.service.dto.UpdateTodoDto;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class TodoServiceTest {  // TODO: 각 테스트 돌릴 때마다 seed 하는 방법
+    @Autowired TodoRepository todoRepository;  // TODO: mock repository로 교체
+    @Autowired TodoService todoService;
+    @Autowired EntityManager em;
+
+    @Test
+    void 할_일_생성() {
+        // given
+        // TODO: 유저 생성
+
+        String testContent = "새로운 할 일";
+
+        // when
+        UUID savedTodoId = todoService.createTodo(testContent);
+
+        // then
+        Todo found = todoRepository.findById(savedTodoId);
+
+        assertThat(found.getId()).isEqualTo(savedTodoId);
+        assertThat(found.getContent()).isEqualTo(testContent);
+        assertThat(found.getIsDone()).isFalse();
+    }
+
+    @Test
+    void 모든_할_일_조회() {
+        // given
+        // TODO: 유저 생성
+
+        Todo todoA = Todo.create("새로운 할 일1");
+        Todo todoB = Todo.create("새로운 할 일2");
+
+        todoRepository.save(todoA);
+        todoRepository.save(todoB);
+
+        // when
+        List<Todo> todos = todoService.findTodos();
+
+        // then
+        assertThat(todos.size()).isEqualTo(2);
+    }
+
+    @Test
+    void 특정_할_일_수정() {
+        // given
+        // TODO: 유저 생성
+        Todo todoA = Todo.create("새로운 할 일1");
+        todoRepository.save(todoA);
+
+        // when
+        todoService.updateTodo(todoA.getId(), new UpdateTodoDto(true));
+
+        // then
+        Todo found = todoRepository.findById(todoA.getId());
+        assertThat(found.getIsDone()).isTrue();
+    }
+
+    @Test
+    void 특정_할_일_삭제() {
+
+        // given
+        // TODO: 유저 생성
+        Todo todoA = Todo.create("새로운 할 일1");
+        todoRepository.save(todoA);
+
+        // when
+        todoService.deleteTodo(todoA.getId());
+
+        // then
+        Todo found = todoRepository.findById(todoA.getId());
+        assertThat(found).isNull();
+    }
+}


### PR DESCRIPTION
## 이슈 번호 또는 링크
https://github.com/users/dawwson/projects/1/views/1?pane=issue&itemId=38818743
<br>

## 💡 변경 이유
새로운 기능 추가
<br>

## 🔑 주요 변경사항
1. Todo 엔티티
  - 비즈니스 로직 추가
  - 생성일 수정일 자동 생성되도록 어노테이션 설정(Spring Data JPA 사용)
2. Todo Repository
  - Todo 저장
  - Todo 검색
  - Todo 수정
  - Todo 삭제
3. Todo Service
  - Todo 생성
  - Todo 조회
  - Todo 수정
  - Todo 삭제
4. Todo Controller
  - 모든 Todo 조회 API (GET /todos)
  - 새로운 Todo 추가 API (POST /todos)
  - Request, Respone DTO 설정
5. 서비스 레이어 유닛 테스트 작성
<br>

## 📷 테스트 결과

### 모든 Todo 조회 API
<img width="1087" alt="image" src="https://github.com/dawwson/todo-app-be/assets/45624238/99f29341-7f36-4a5d-82fd-d5af6aa88b89">

### 새로운 Todo 추가 API
<img width="1096" alt="image" src="https://github.com/dawwson/todo-app-be/assets/45624238/5352f01f-893a-4b73-b9c5-717040e83018">

<img width="996" alt="image" src="https://github.com/dawwson/todo-app-be/assets/45624238/ee258234-d1d3-44b2-9cec-cdd955da69d0">

<br>

## 남은 할 일 
- [ ] 통합 테스트 작성
- [ ] Todo 수정, 삭제 API 완성
- [ ] User 엔티티와 연결 로직 추가
- [ ] Request Body Validation 할 때 타입 에러 발생시키는 방법 알아보기